### PR TITLE
do not call ImageFont.truetype with font size of 0

### DIFF
--- a/src/blockdiag/imagedraw/png.py
+++ b/src/blockdiag/imagedraw/png.py
@@ -100,6 +100,8 @@ def style2cycle(style, thick):
 
 
 def ttfont_for(font):
+    if font.size <= 0:
+        return None
     if font.path:
         path, index = parse_fontpath(font.path)
         if index:


### PR DESCRIPTION
fixes: https://github.com/blockdiag/blockdiag/issues/183