### PR TITLE
remove legacy urlparse import

### DIFF
--- a/src/blockdiag/utils/urlutil.py
+++ b/src/blockdiag/utils/urlutil.py
@@ -13,10 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse as urlparse
+import urllib.parse as urlparse
 
 
 def isurl(url):


### PR DESCRIPTION
"import urlparse" is a legacy from python 2

We don't support python 2 anymore, so we can remove the legacy path.