### PR TITLE
remove obsolete use of pkg_resource

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         'setuptools',
         'funcparserlib>=1.0.0a0',

--- a/src/blockdiag/imagedraw/__init__.py
+++ b/src/blockdiag/imagedraw/__init__.py
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pkg_resources
+from importlib import metadata
 
 from blockdiag.utils.logging import warning
 
@@ -21,14 +21,14 @@ drawers = {}
 
 
 def init_imagedrawers(debug=False):
-    for drawer in pkg_resources.iter_entry_points('blockdiag_imagedrawers'):
+    for drawer in metadata.entry_points(group='blockdiag_imagedrawers'):
         try:
             module = drawer.load()
             if hasattr(module, 'setup'):
                 module.setup(module)
         except Exception as exc:
             if debug:
-                warning('Failed to load %s: %r' % (drawer.module_name, exc))
+                warning('Failed to load %s: %r' % (drawer.name, exc))
 
 
 def install_imagedrawer(ext, drawer):

--- a/src/blockdiag/noderenderer/__init__.py
+++ b/src/blockdiag/noderenderer/__init__.py
@@ -15,14 +15,14 @@
 
 from __future__ import division
 
-import pkg_resources
+from importlib import metadata
 
 renderers = {}
 searchpath = []
 
 
 def init_renderers():
-    for plugin in pkg_resources.iter_entry_points('blockdiag_noderenderer'):
+    for plugin in metadata.entry_points(group='blockdiag_noderenderer'):
         module = plugin.load()
         if hasattr(module, 'setup'):
             module.setup(module)

--- a/src/blockdiag/plugins/__init__.py
+++ b/src/blockdiag/plugins/__init__.py
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from pkg_resources import iter_entry_points
+from importlib import metadata
 
 from blockdiag.utils.logging import warning
 
@@ -28,7 +28,7 @@ def load(plugins, diagram, **kwargs):
             warning('plugin "%s" is already loaded. ignored.', name)
             return
 
-        for ep in iter_entry_points('blockdiag_plugins', name):
+        for ep in metadata.entry_points(group='blockdiag_plugins', name=name):
             module = ep.load()
             loaded_plugins.append(name)
             if hasattr(module, 'setup'):


### PR DESCRIPTION
pkg_resource is obsolete, and support will be removed in September 2024. Instead, we use importlib.metadata. It forces us to drop python 3.7 support. But that version of python is not supported anymore.