### PR TITLE
Replace unsupported build-base directive

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 ;tag_build = dev
 
 [build]
-build-base = _build
+build_base = _build
 
 [sdist]
 formats = gztar


### PR DESCRIPTION
When building blockdiag, the following warning appears:

> Usage of dash-separated 'build-base' will not be supported in future
> versions. Please use the underscore name 'build_base' instead.

> By 2024-Sep-26, you need to update your project and remove deprecated calls
> or your builds will no longer be supported.

This patchs fixes it by switching build-base to build_base.