### PR TITLE
fixes: python -m build fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,10 @@ jobs:
             toxenv: pillow8.x
           - python-version: '3.11'
             toxenv: pillow9.x
+          - python-version: '3.11'
+            toxenv: sdist
+          - python-version: '3.11'
+            toxenv: wheel
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "docutils"]
+build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{310,311},pillow{8.x,9.x},flake8
+envlist=py{310,311},pillow{8.x,9.x},flake8,sdist,wheel
 
 [testenv]
 usedevelop = True
@@ -15,6 +15,16 @@ passenv =
     ALL_TESTS
 commands =
     pytest
+
+[testenv:sdist]
+description = Build a source distribution
+deps = build
+commands = python -m build --sdist
+
+[testenv:wheel]
+description = Build a binary distribution
+deps = build
+commands = python -m build --wheel
 
 [testenv:flake8]
 description =


### PR DESCRIPTION
python -m build fails with:
> running check
> error: The docutils package is needed.

since check.restructuredtext is set to 1 in setup.cfg, setuptools with require docutils. I think this is needed to parse the structured text README.
That dependency needs to be specify in pyproject.toml file. It is recommended practice to have a pyproject.toml file anyway. https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#should-pyproject-toml-be-added