### PR TITLE
remove useless exclude declaration in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,3 @@ include tests/VLGothic/*
 recursive-include examples blockdiagrc *.diag *.png *.svg
 recursive-include src *.py
 recursive-include tests README *.py *.diag *.gif *.png
-
-exclude examples/update.sh


### PR DESCRIPTION
examples/update.sh is not included by the  recursive-include rule above. This results in the following warning when building a source distribution:
warning: no previously-included files found matching 'examples/update.sh